### PR TITLE
Added app-arch/lz4 to profile. Needed to build our kvm kernels

### DIFF
--- a/profiles/stepping-stone.ch/kvm/packages
+++ b/profiles/stepping-stone.ch/kvm/packages
@@ -5,6 +5,7 @@
 *app-admin/sst-syslog-ng-configuration
 *app-admin/sudo
 *app-admin/syslog-ng
+*app-arch/lz4
 *app-arch/unzip
 *app-arch/zip
 *app-backup/onlinebackup


### PR DESCRIPTION
Add lz4 to profile. It is needed to build our kernels on the kvm-vms
