### PR TITLE
profiles/stepping-stone.ch/kvm: Switch parents to the updated 17.0 pr…

### DIFF
--- a/profiles/stepping-stone.ch/kvm/amd64/no-multilib/parent
+++ b/profiles/stepping-stone.ch/kvm/amd64/no-multilib/parent
@@ -1,2 +1,2 @@
-gentoo:hardened/linux/amd64/no-multilib
+gentoo:default/linux/amd64/17.0/no-multilib/hardened
 ../..

--- a/profiles/stepping-stone.ch/kvm/amd64/parent
+++ b/profiles/stepping-stone.ch/kvm/amd64/parent
@@ -1,2 +1,2 @@
-gentoo:hardened/linux/amd64
+gentoo:default/linux/amd64/17.0/hardened
 ..

--- a/profiles/stepping-stone.ch/make.defaults
+++ b/profiles/stepping-stone.ch/make.defaults
@@ -13,7 +13,11 @@ LDFLAGS="-Wl,-O1,--hash-style=gnu,--sort-common -Wl,--as-needed"
 # -X: certain packages have USE=+X set (java, I'm looking at you)... ignore that
 # -ruby_targets_ruby19: the RUBY_TARGETS USE_EXPAND var is set to contain both ruby20 and ruby21,
 #                       but since puppet works with ruby21 we do not need ruby20 and we can't override RUBY_TARGETS in this make.defaults
-USE="${USE} ${CPU_FLAGS_X86} bash-completion caps unicode xattr vim-syntax -alsa -cups -tcpd -X -ruby_targets_ruby20"
+USE="${USE} ${CPU_FLAGS_X86} bash-completion caps unicode xattr vim-syntax -alsa -cups -tcpd -X"
+
+# Add missing USE flags when switching to the new 17.0 profile.
+# See https://github.com/stepping-stone/sst-gentoo-overlay/pull/11
+USE="${USE} berkdb gdbm urandom"
 
 # Use our and Switch's mirror for distfiles
 GENTOO_MIRRORS="https://mirror.stepping-stone.ch/public/gentoo http://mirror.switch.ch/ftp/mirror/gentoo"


### PR DESCRIPTION
…ofiles

The old 'hardened/linux/amd64/no-multilib' profiles have been deprecated a while ago. At the start of 2019 they have now been removed from the upstream Portage Tree entirely. This caused our profile to effectively break.